### PR TITLE
Use mirror of swift-collections v1.1 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ DerivedData/
 .netrc
 .swiftpm
 docs/
+.sublime-workspace

--- a/Package.resolved
+++ b/Package.resolved
@@ -19,12 +19,12 @@
       }
     },
     {
-      "identity" : "swift-collections",
+      "identity" : "swift-collections-v1_1-fork",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections.git",
+      "location" : "https://github.com/GoodHatsLLC/swift-collections-v1_1-fork.git",
       "state" : {
-        "branch" : "release/1.1",
-        "revision" : "d8003787efafa82f9805594bc51100be29ac6903"
+        "revision" : "d8003787efafa82f9805594bc51100be29ac6903",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -111,8 +111,8 @@ let package = Package(
       "0.8.5" ..< "0.9.0"
     ),
     .package(
-      url: "https://github.com/apple/swift-collections.git",
-      branch: "release/1.1"
+      url: "https://github.com/GoodHatsLLC/swift-collections-v1_1-fork.git",
+      "1.1.0" ..< "1.2.0"
     ),
     .package(
       url: "https://github.com/apple/swift-docc-plugin",
@@ -135,7 +135,7 @@ let package = Package(
       name: "Utilities",
       dependencies: [
         "Disposable",
-        .product(name: "OrderedCollections", package: "swift-collections"),
+        .product(name: "OrderedCollections", package: "swift-collections-v1_1-fork"),
       ],
       swiftSettings: Build.globalSwiftSettings
     ),
@@ -158,8 +158,8 @@ let package = Package(
         "Intents",
         "TreeActor",
         "Utilities",
-        .product(name: "HeapModule", package: "swift-collections"),
-        .product(name: "OrderedCollections", package: "swift-collections"),
+        .product(name: "HeapModule", package: "swift-collections-v1_1-fork"),
+        .product(name: "OrderedCollections", package: "swift-collections-v1_1-fork"),
       ],
       swiftSettings: Build.globalSwiftSettings
     ),
@@ -205,7 +205,7 @@ let package = Package(
       dependencies: [
         "StateTree",
         "Disposable",
-        .product(name: "HeapModule", package: "swift-collections"),
+        .product(name: "HeapModule", package: "swift-collections-v1_1-fork"),
       ]
     ),
     .testTarget(


### PR DESCRIPTION
As per [SPM docs](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageDescription.md)

> Note that packages which use branch-based dependency requirements can't be added as dependencies to packages that use version-based dependency requirements; you should remove branch-based dependency requirements before publishing a version of your package.

StateTree depends on `swift-collections` [v1.1](https://github.com/apple/swift-collections/tree/release/1.1) which is on a pre-release branch — and so can't be added to some projects when checked out at the `v0.1.0` tag.


fixes: #21