### PR TITLE
Use main queue in StateTreeSwiftUI PlaybackView

### DIFF
--- a/Sources/StateTreeSwiftUI/Views/PlaybackView.swift
+++ b/Sources/StateTreeSwiftUI/Views/PlaybackView.swift
@@ -1,3 +1,4 @@
+import Dispatch
 import Disposable
 import Emitter
 import StateTree
@@ -187,6 +188,7 @@ public struct PlaybackView<Root: Node, NodeView: View>: View {
           .replaceFailures(with: 0)
         }
         .asCombinePublisher()
+        .receive(on: DispatchQueue.main)
     ) { loc in
       switch mode {
       case .record(let recorder): frameRange = recorder.frameRangeDouble


### PR DESCRIPTION
Prevent SwiftUI code in `StateTreeSwiftUI` from receiving updates off of the main thread.