### PR TITLE
Note wider product version compatibility

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -26,24 +26,6 @@
         "revision" : "d8003787efafa82f9805594bc51100be29ac6903",
         "version" : "1.1.0"
       }
-    },
-    {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
-      "state" : {
-        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
-        "version" : "1.2.0"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -74,6 +74,9 @@ let package = Package(
   platforms: [
     .macOS("12.3"),
     .iOS("15.4"),
+    .tvOS("15.4"),
+    .watchOS("8.5"),
+    .macCatalyst("15.4"),
   ],
   products: [
     .library(

--- a/Package.swift
+++ b/Package.swift
@@ -117,10 +117,6 @@ let package = Package(
       url: "https://github.com/GoodHatsLLC/swift-collections-v1_1-fork.git",
       "1.1.0" ..< "1.2.0"
     ),
-    .package(
-      url: "https://github.com/apple/swift-docc-plugin",
-      from: "1.1.0"
-    ),
   ],
   targets: [
     .target(


### PR DESCRIPTION
* add version compatibility info for tvOS, watchOS, and macCatalyst
* remove swift-docc-plugin dependency
  - it shouldn't have to be in the package to generate a website