### PR TITLE
Add a cross-platform test script

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -225,10 +225,10 @@ private enum Env {
 
   static let supportsSwiftUI: Bool = {
     if !treeActorIsNonMain, canImportSwiftUI {
-      verboseContext("[🍎 - SwiftUI build enabled]")
+      verboseContext("[🎨 - SwiftUI build enabled]")
       return true
     } else {
-      verboseContext("[🐧 - SwiftUI build disabled]")
+      verboseContext("[📵 - SwiftUI build disabled]")
       return false
     }
   }()
@@ -242,13 +242,21 @@ private enum Env {
   // MARK: Private
 
   private static let treeActorIsNonMain: Bool = {
-    ProcessInfo.processInfo.environment["CUSTOM_ACTOR"] == "1"
+    if ProcessInfo.processInfo.environment["CUSTOM_ACTOR"] == "1" {
+      verboseContext("[🎄 - @TreeActor != @MainActor]")
+      return true
+    } else {
+      verboseContext("[🌳 - @TreeActor == @MainActor]")
+      return false
+    }
   }()
 
   private static let canImportSwiftUI: Bool = {
     #if !canImport(SwiftUI)
+    verboseContext("[🐧 - SwiftUI is unavailable]")
     return false
     #else
+    verboseContext("[🍎 - SwiftUI can be imported]")
     return true
     #endif
   }()

--- a/scripts/dkr
+++ b/scripts/dkr
@@ -2,4 +2,4 @@
 
 IMG='swift:5.8.1'
 
-docker  run  -v "$(pwd)":"$(pwd)" -w "$(pwd)" -i -t  -a stdout -a stderr "${IMG}" "${@}"
+docker run  -v "$(pwd)":"$(pwd)" -w "$(pwd)" -i -t  -a stdout -a stderr "${IMG}" "${@}"

--- a/scripts/test
+++ b/scripts/test
@@ -1,5 +1,46 @@
 #!/bin/bash
 
->/dev/null pushd "$(git rev-parse --show-toplevel)/scripts" || exit 1
+>/dev/null pushd "$(git rev-parse --show-toplevel)/scripts" || exit 1 ;
 
-./runswift "${@}" test
+DIDFAIL=0
+
+echo "📝 Test Suite"
+echo ""
+
+if uname | >/dev/null grep Darwin; then
+  echo "⌛1️⃣ macOS build (TreeActor == MainActor)"
+  ./runswift -v test || DIDFAIL=1
+  echo ""
+  echo ""
+  echo "⌛2️⃣ macOS build (TreeActor != MainActor)"
+  ./runswift -v -c test || DIDFAIL=1
+  echo ""
+  echo ""
+else
+  >&2 echo "❗ no macOS builds"
+  >&2 echo ""
+  >&2 echo ""
+  DIDFAIL=1
+fi
+
+>/dev/null pushd "$(git rev-parse --show-toplevel)" || exit 1 ;
+
+if ./scripts/dkr uname | >/dev/null grep Linux; then
+  echo "⌛3️⃣ Linux build"
+  ./scripts/dkr ./scripts/runswift -v test || DIDFAIL=1
+  echo ""
+  echo ""
+else
+  >&2 echo "❗ no Linux build"
+  >&2 echo ""
+  >&2 echo ""
+  DIDFAIL=1
+fi
+
+if [ $DIDFAIL != 0 ]; then
+  >&2 echo "⛔ Failures present"
+  exit 1
+else
+  echo "✅ Tests succeeded"
+  exit 0
+fi


### PR DESCRIPTION
`./scripts/test` will runs the suite:
- on the native mac with regular UI-mode `@TreeActor == @MainActor`.
- on the native mac without SwiftUI, with a custom `@TreeActor`.
- on linux via docker, without SwiftUI.